### PR TITLE
Improve XBDM interface

### DIFF
--- a/xboxpy/interface/if_xbdm.py
+++ b/xboxpy/interface/if_xbdm.py
@@ -26,20 +26,34 @@ def xbdm_read_line():
     data += byte
   return data
 
-def xbdm_parse_response2(length=None):
+def xbdm_parse_response(length=None):
   try:
     res = xbdm_read_line()
-    if res[3] != 45: #b'-': #FIXME: how to compare a single letter to a byte string element?
+    if res[3] != ord('-'):
       raise
     status = int(res[0:3])
+    if res[4] != ord(' '):
+      raise
+    res = res[5:]
   except:
     return (None, None)
+
   if status == 200:
-    assert(res[0:5] == b'200- ')
-    return (status, str(res[5:], encoding='ascii'))
-  if status == 201:
     return (status, str(res, encoding='ascii'))
-  if status == 203:
+
+  elif status == 201:
+    return (status, str(res, encoding='ascii'))
+
+  elif status == 202:
+    lines = []
+    while True:
+      line = xbdm_read_line()
+      if line == b'.': #end of response
+        break
+      lines += [str(line, encoding='ascii')]
+    return (status, lines)
+
+  elif status == 203:
     res = bytearray()
 
     # This will not work with most commands, but "getfile" prefixes the
@@ -55,32 +69,31 @@ def xbdm_parse_response2(length=None):
       assert(remaining > 0)
       res += xbdm.recv(remaining)
     return (status, bytes(res))
-  if status == 202:
-    lines = []
-    while True:
-      line = xbdm_read_line()
-      if line == b'.': #end of response
-        break
-      lines += [str(line, encoding='ascii')]
-    return (status, lines)
-  print("Unknown status: " + str(status))
-  print("from response: " + str(res))
-  #FIXME: Read remaining buffer?!
-  assert(False)
+
+  elif status == 204:
+    return (status, str(res, encoding='ascii'))
+
+  else:
+    print("Unknown status: " + str(status))
+    print("from response: " + str(res))
+    #FIXME: Read remaining buffer?!
+
   return (status, res)
 
-#FIXME: For legacy reasons, should be updated?
-def xbdm_parse_response(length=None):
-  return xbdm_parse_response2(length)[1]
-
-def xbdm_command(cmd, length=None):
+def xbdm_command(cmd, data=None, length=None):
   #FIXME: If type is already in bytes we just send it binary!
   #print("Running '" + cmd + "'")
   xbdm.send(bytes(cmd + "\r\n", encoding='ascii'))
   #print("Sent")
-  lines = xbdm_parse_response(length)
+  status, lines = xbdm_parse_response(length)
+
+  # Respond with requested data
+  if status == 204:
+    xbdm.send(data)
+    status, lines = xbdm_parse_response()
+
   #print("Done")
-  return lines
+  return status, lines
 
 import re
 
@@ -110,7 +123,7 @@ def xbdm_parse_keys(string):
 
 def GetModules():
   modulesList = []
-  lines = xbdm_command("modules")
+  status, lines = xbdm_command("modules")
 
   for line in lines:
     module = xbdm_parse_keys(line)
@@ -124,7 +137,7 @@ def GetMem(addr, length):
     return bytes([])
   if False:
     cmd = "getmem addr=0x" + format(addr, 'X') + " length=0x" + format(length, 'X')
-    lines = xbdm_command(cmd)
+    status, lines = xbdm_command(cmd)
     data = bytearray()
     for line in lines:
       line = str(line, encoding='ascii').strip()
@@ -137,7 +150,7 @@ def GetMem(addr, length):
     assert(len(data) == length)
   else:
     cmd = "getmem2 addr=0x" + format(addr, 'X') + " length=0x" + format(length, 'X')
-    data = xbdm_command(cmd, length)
+    status, data = xbdm_command(cmd, length=length)
   return bytes(data)
 
 def SetMem(addr, data):
@@ -183,7 +196,7 @@ def connect():
         sys.exit("Unknown connection error")
     # Get login message
     try:
-      (status, data) = xbdm_parse_response2()
+      status, data = xbdm_parse_response()
       if status == None:
         raise
       if status != 201:

--- a/xboxpy/interface/if_xbdm.py
+++ b/xboxpy/interface/if_xbdm.py
@@ -41,6 +41,12 @@ def xbdm_parse_response2(length=None):
     return (status, str(res, encoding='ascii'))
   if status == 203:
     res = bytearray()
+
+    # This will not work with most commands, but "getfile" prefixes the
+    # transfer with the actual length, so we need to support it.
+    if length == 0:
+      length = struct.unpack("<I", xbdm.recv(4))[0]
+
     assert(length != None)
     while True:
       remaining = length - len(res)
@@ -104,6 +110,8 @@ def GetModules():
   return modulesList
 
 def GetMem(addr, length):
+  if length == 0:
+    return bytes([])
   if False:
     cmd = "getmem addr=0x" + format(addr, 'X') + " length=0x" + format(length, 'X')
     lines = xbdm_command(cmd)

--- a/xboxpy/interface/if_xbdm.py
+++ b/xboxpy/interface/if_xbdm.py
@@ -35,7 +35,8 @@ def xbdm_parse_response2(length=None):
   except:
     return (None, None)
   if status == 200:
-    return (status, res)
+    assert(res[0:5] == b'200- ')
+    return (status, str(res[5:], encoding='ascii'))
   if status == 201:
     return (status, str(res, encoding='ascii'))
   if status == 203:

--- a/xboxpy/interface/if_xbdm.py
+++ b/xboxpy/interface/if_xbdm.py
@@ -61,7 +61,7 @@ def xbdm_parse_response2(length=None):
       line = xbdm_read_line()
       if line == b'.': #end of response
         break
-      lines += [line]
+      lines += [str(line, encoding='ascii')]
     return (status, lines)
   print("Unknown status: " + str(status))
   print("from response: " + str(res))

--- a/xboxpy/interface/if_xbdm.py
+++ b/xboxpy/interface/if_xbdm.py
@@ -261,7 +261,7 @@ def xbdm_call(address, stack):
 
 def read2(address, size, physical):
   if physical:
-    address |= 0x80000000
+    assert(False)
   if hacked:
     if size == 1:
       return xbdm_read_8(address)[0:1]
@@ -272,7 +272,7 @@ def read2(address, size, physical):
   return GetMem(address, size)
 def write2(address, data, physical):
   if physical:
-    address |= 0x80000000
+    assert(False)
   if hacked:
     size = len(data)
     if size == 1:


### PR DESCRIPTION
This adds support for "getfile" style requests and cleans up the response format.
If there are more binary response formats, this will probably be refactored again; however, for now, this feels like an okay solution.

The PR also adds a parser for key/value pairs as typically returned by XBDM.
This might need a full refactor in the future, if auto-detection of response types is not possible (which is an assumption this code depends on).
The new code also requires the regular-expression module, which should be avoided in the future.
The code also does 2 passes: one to find key/value pairs, and one to find keys without values (tags). This is bad design, but I don't have time to improve it at the moment.
A key/value string creation function was also planned, but will happen in a follow-up, sometime in the future. This will eventually lead to a full refactor of the XBDM command interface in xboxpy.

Physical memory access was disabled, and it will probably be removed from the xboxpy API in the future.

`xbdm_command` will also return status codes now, and supports handling of status 204 (request for binary data).
