### PR TITLE
Only keep correct `Unswizzle` function

### DIFF
--- a/xboxpy/nv2a.py
+++ b/xboxpy/nv2a.py
@@ -67,7 +67,7 @@ def GetSwizzledOffset(offset, mask, bits_per_pixel):
 def Swizzle():
   assert(False)
 
-def _Unswizzle(data, bits_per_pixel, size, pitch):
+def Unswizzle(data, bits_per_pixel, size, pitch):
   assert(bits_per_pixel % 8 == 0)
   bytes_per_pixel = bits_per_pixel // 8
 
@@ -82,11 +82,11 @@ def _Unswizzle(data, bits_per_pixel, size, pitch):
   data = bytes(data)
   unswizzled = bytearray([0] * len(data))
 
-  print(size)
+  #print(size)
   mask = GenerateSwizzleMask(size)
-  print(bin(mask[0]).rjust(34))
-  print(bin(mask[1]).rjust(34))
-  print(bin(mask[2]).rjust(34))
+  #print(bin(mask[0]).rjust(34))
+  #print(bin(mask[1]).rjust(34))
+  #print(bin(mask[2]).rjust(34))
 
   for z in range(0, size[2]):
     for y in range(0, size[1]):
@@ -99,100 +99,4 @@ def _Unswizzle(data, bits_per_pixel, size, pitch):
           unswizzled[dst+i] = b
         #unswizzled[dst:dst + bytes_per_pixel] = data[src:src + bytes_per_pixel]
 
-      #if y == 190:
-      #  return unswizzled
-
-
   return bytes(unswizzled)
-
-
-# Ugly unswizzle code by xbox7887 follows
-block = [ 0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14, 15,
-         18, 19,
-         16, 17,
-         22, 23,
-         20, 21,
-         26, 27,
-         24, 25,
-         30, 31,
-         28, 29,
-         33, 34, 35,
-         32,
-         37, 38, 39,
-         36,
-         41, 42, 43,
-         40,
-         45, 46, 47,
-         44,
-         51,
-         48, 49, 50,
-         55,
-         52, 53, 54,
-         59,
-         56, 57, 58,
-         63,
-         60, 61, 62 ]
-def Unswizzle(data, bits_per_pixel, size, pitch):
-  data = bytes(data)
-  unswizzled = bytearray([0] * len(data))
-
-  assert(len(size) == 2)
-  assert(size[0] == 640)
-  assert(size[1] <= 480)
-  assert(pitch == 2560)
-  assert(bits_per_pixel == 32)
-
-  swiz = 0
-  index = 0
-  offset = 0
-  deswiz = 0
-
-  width = size[0]
-  height = size[1]
-
-  for y in range(0, height): # 30
-      for x in range(0, width): # 10
-          blockX = x // 64
-          blockY = y // 16
-
-          offY = y % 16
-          offX = x % 64
-
-          if offX != 0:
-              continue
-
-          for l in range(0, 4):
-                index = l * 16 + offY
-                bv = block[index]
-                offset = ((bv // 4) * 256) + ((bv % 4) * 16)
-
-                for i in range(0, 4):
-                    for v in range(0, 4):
-                          s = (blockY * 10 + blockX) * 4096
-                          s += i * 64
-
-                          d = 0
-                          d += pitch*(height-1) # Go to end of image
-                          d -= blockY * (17 * pitch) # Go up 17 lines?!
-                          d += (blockY * 10 + blockX) * (16 * pitch + 256)
-                          d -= ((blockY * 10 + blockX) * 4 + l) * (4 * pitch + 256)
-                          d += (((blockY * 10 + blockX) * 4 + l) * 16 + offY) * 16
-                          d -= pitch * i
-
-                          if True:
-                            if ((blockY & 1) == 1):
-                                if ((blockX & 1) == 1):
-                                  d -= 256
-                                else:
-                                  d += 256
-
-                          for channel in range(0, 3):
-                            o = v * 4 + channel
-                            b = data[s + offset + o]
-                            unswizzled[d + o] = b
-
-  flipped = bytearray([0] * len(unswizzled))
-  for i in range(0, size[1]):
-    flipped[i*pitch:(i+1)*pitch] = unswizzled[-pitch*(i+1):-pitch*i]
-
-  return bytes(flipped)


### PR DESCRIPTION
The existing `Unswizzle` function was doing unswizzling and untiling in the same step.
It has been removed.

The existing `_Unswizzle` function only does the unswizzle step.
It will therefore become the new `Unswizzle` (without leading underscore).

Debug printing has been disabled as to not confuse users.

---

Mostly closes #6.
Some swizzling modes still aren't supported, but the linked issue is too generic for that.
A new issue about lack of tiling support should also be opened.

This change has not been tested yet, and some users of xboxpy will require patches (such as nv2a-trace) due to API breakage.